### PR TITLE
example uses incorrect name for variable containing form

### DIFF
--- a/lib/Form/Tiny/Manual.pod
+++ b/lib/Form/Tiny/Manual.pod
@@ -42,7 +42,7 @@ Form::Tiny::Manual - reference for working with Form::Tiny
 		lucky_number => 6,
 	});
 
-	if ($input->valid) {
+	if ($form->valid) {
 		print Dumper $form->fields;
 	}
 	else {


### PR DESCRIPTION
fix for #9 